### PR TITLE
Pass styles through to dcc.Loading node when loaded

### DIFF
--- a/src/components/Loading.react.js
+++ b/src/components/Loading.react.js
@@ -55,7 +55,7 @@ export default class Loading extends Component {
             type(this.props.children) !== 'Object' ||
             type(this.props.children) !== 'Function'
         ) {
-            return <div className={className}>{this.props.children}</div>;
+            return <div className={className} style={style}>{this.props.children}</div>;
         }
         return this.props.children;
     }


### PR DESCRIPTION
The style dictionary is present when the dcc.Loading component is loading, but not when it is loaded. This causes problems if you have layout styling on the Loading node (like height, or flex-grow). This seems like it was just an oversight.